### PR TITLE
Designate domains to include or skip via cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,31 @@ ansible-playbook playbook.yml
 
 So you can see with the tags, there's many options for how you use this playbook!
 
+### Running play for only specific domains
+It is also possible to only include or exclude specific domains defined in your `vars.yml` file.  One scenario where this would be useful is if you wanted to speed up the deploy of a new site for a domain to the server.  
+
+To do this, you utilize the `-e` flag on the `ansible-playbook` command to pass along extra variables that this playbook will listen for:
+
+`include_domains`: Any domains listed here will be _included_ in the play.
+`exclude_domains`: Any domains listed here will be _excluded_ from the play.  Note: if you have the same domain listed with both variables, exclude will override include.
+
+**Example A: Including domains**
+
+In the following example, only the `testc.mydomain.com` and `testd.mydomain.com` sites from your `vars.yml` file will have the play executed on them.
+
+```
+ansible-playbook playbook.yml -e "include_domains=testc.mydomain.com,testd.mydomain.com"
+```
+
+**Example B: Excluding domains**
+
+In the following example, both `testc.mydomain.com` and `testd.mydomain.com` sites from your `vars.yml` file will be excluded form the playbook execution.
+
+```
+ansible-playbook playbook.yml -e "exclude_domains=testc.mydomain.com,testd.mydomain.com"
+```
+
+
 ## Directory structure for created sites:
 
 The following structure is used for the WordPress sites created:

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,6 +1,16 @@
 ---
 ### New playbook
 - hosts: webservers
+  ## if you want to only have specific domains from your `vars.yml` file to be executed then you can use the
+  ## `-e` command line flag to send in either the domains to include via a `include_domains` var, or domains to exclude
+  ## via a `skip_domains` variable.
+  ## Example:
+  ## $:> ansible-playbook playbook.yml -e "include_domains=domaina.com,domainb.com,domainc.com"
+  vars:
+    domuse: "{{ include_domains | default('all') }}"
+    domains_to_use: "{{ domuse.split(',') }}"
+    domskip: "{{ skip_domains | default('none') }}"
+    domains_to_skip: "{{ domskip.split(',') }}"
   vars_files:
     - vars.yml
   remote_user: "{{ remote_sudo_user }}"

--- a/roles/gitdeploy/tasks/main.yml
+++ b/roles/gitdeploy/tasks/main.yml
@@ -8,6 +8,11 @@
     stat:
       path: /home/{{ remote_web_user }}/{{ item.git_deploy.hubdirectory }}/hooks/post-update
     register: hubsetup
+    when: >
+      (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
+      and item.name not in domains_to_skip
+      and item.git_deploy is defined
+      and item.git_deploy.hubdirectory is defined
     with_items:
       - "{{ domains }}"
 
@@ -15,7 +20,12 @@
     file:
       path: /home/{{ remote_web_user }}/{{ item.0.git_deploy.hubdirectory }}
       state: directory
-    when: '"/home/"+remote_web_user+"/"+item.0.git_deploy.hubdirectory+"/hooks/post-update" == item.1.invocation.module_args.path and not item.1.stat.exists'
+    when: >
+      (item.1.skipped is undefined or not item.1.skipped)
+      and "/home/"+remote_web_user+"/"+item.0.git_deploy.hubdirectory+"/hooks/post-update" == item.1.invocation.module_args.path
+      and not item.1.stat.exists
+      and item.0.git_deploy is defined
+      and item.0.git_deploy.hubdirectory is defined
     with_nested:
       - "{{ domains }}"
       - "{{ hubsetup.results }}"
@@ -24,7 +34,12 @@
     command: git init --bare
     args:
       chdir: /home/{{ remote_web_user }}/{{ item.0.git_deploy.hubdirectory }}
-    when: '"/home/"+remote_web_user+"/"+item.0.git_deploy.hubdirectory+"/hooks/post-update" == item.1.invocation.module_args.path and not item.1.stat.exists'
+    when: >
+      (item.1.skipped is undefined or not item.1.skipped)
+      and "/home/"+remote_web_user+"/"+item.0.git_deploy.hubdirectory+"/hooks/post-update" == item.1.invocation.module_args.path
+      and not item.1.stat.exists
+      and item.0.git_deploy is defined
+      and item.0.git_deploy.hubdirectory is defined
     with_nested:
       - "{{ domains }}"
       - "{{ hubsetup.results }}"
@@ -34,7 +49,12 @@
       src: full-post-update-hub.j2
       dest: /home/{{ remote_web_user }}/{{ item.0.git_deploy.hubdirectory }}/hooks/post-update
       mode: 0755
-    when: '"/home/"+remote_web_user+"/"+item.0.git_deploy.hubdirectory+"/hooks/post-update" == item.1.invocation.module_args.path and not item.1.stat.exists'
+    when: >
+      (item.1.skipped is undefined or not item.1.skipped)
+      and "/home/"+remote_web_user+"/"+item.0.git_deploy.hubdirectory+"/hooks/post-update" == item.1.invocation.module_args.path
+      and not item.1.stat.exists
+      and item.0.git_deploy is defined
+      and item.0.git_deploy.hubdirectory is defined
     with_nested:
       - "{{ domains }}"
       - "{{ hubsetup.results }}"
@@ -45,7 +65,12 @@
       dest: /home/{{ remote_web_user }}/{{ item.0.git_deploy.hubdirectory }}/hooks/post-update
       marker: "# --- {mark} ANSIBLE INSERTED BLOCK ---"
       insertbefore: exec git-update-server-info
-    when: '"/home/"+remote_web_user+"/"+item.0.git_deploy.hubdirectory+"/hooks/post-update" == item.1.invocation.module_args.path and not item.1.stat.exists'
+    when: >
+      (item.1.skipped is undefined or not item.1.skipped)
+      and "/home/"+remote_web_user+"/"+item.0.git_deploy.hubdirectory+"/hooks/post-update" == item.1.invocation.module_args.path
+      and not item.1.stat.exists
+      and item.0.git_deploy is defined
+      and item.0.git_deploy.hubdirectory is defined
     with_nested:
       - "{{ domains }}"
       - "{{ hubsetup.results }}"
@@ -58,21 +83,34 @@
     register: remote_set
     with_items:
       - "{{ domains }}"
+    when: >
+      (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
+      and item.name not in domains_to_skip
+      and item.git_deploy is defined
+      and item.git_deploy.hubdirectory is defined
 
   - name: Delete wp-content folder
     file:
       path: /home/{{ remote_web_user }}/www/{{ item.0.name }}/wp-content
       state: absent
-    when: '"/home/"+remote_web_user+"/www/"+item.0.name+"/wp-content" == item.1.invocation.module_args.chdir and item.1.rc != 0'
     with_nested:
       - "{{ domains }}"
       - "{{ remote_set.results }}"
+    when: >
+      (item.1.skipped is undefined or not item.1.skipped)
+      and item.0.name == item.1.item.name
+      and item.1.rc != 0
+      and item.0.git_deploy is defined
 
   - name: Recreate blank wp-content folder
     file:
       path: /home/{{ remote_web_user }}/www/{{ item.0.name }}/wp-content
       state: directory
-    when: '"/home/"+remote_web_user+"/www/"+item.0.name+"/wp-content" == item.1.invocation.module_args.chdir and item.1.rc != 0'
+    when: >
+      (item.1.skipped is undefined or not item.1.skipped)
+      and item.0.name == item.1.item.name
+      and item.1.rc != 0
+      and item.0.git_deploy is defined
     with_nested:
       - "{{ domains }}"
       - "{{ remote_set.results }}"
@@ -81,7 +119,12 @@
     command: git clone -o {{ item.0.git_deploy.hubdirectory }} /home/{{ remote_web_user }}/{{ item.0.git_deploy.hubdirectory }} wp-content
     args:
       chdir: /home/{{ remote_web_user }}/www/{{ item.0.name }}
-    when: '"/home/"+remote_web_user+"/www/"+item.0.name+"/wp-content" == item.1.invocation.module_args.chdir and item.1.rc != 0'
+    when: >
+      (item.1.skipped is undefined or not item.1.skipped)
+      and item.0.name == item.1.item.name
+      and item.1.rc != 0
+      and item.0.git_deploy is defined
+      and item.0.git_deploy.hubdirectory is defined
     with_nested:
       - "{{ domains }}"
       - "{{ remote_set.results }}"

--- a/roles/importdb/tasks/main.yml
+++ b/roles/importdb/tasks/main.yml
@@ -7,7 +7,10 @@
     module: stat
     path: "{{ item.wp.db_import.path }}"
   register: import_src_paths
-  when: item.wp.db_import is defined and item.wp.db_import.path is defined
+  when: >
+    item.wp.db_import is defined and item.wp.db_import.path is defined
+    and (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
+    and item.name not in domains_to_skip
   with_items:
     - "{{ domains }}"
 
@@ -18,7 +21,12 @@
     copy:
       src: "{{ item.0.wp.db_import.path }}"
       dest: /home/{{ remote_web_user }}/www/{{ item.0.name }}/import.sql
-    when: item.0.wp.db_import is defined and item.0.wp.db_import.path is defined and item.1.stat.path == item.0.wp.db_import.path and item.1.stat.exists
+    when: >
+      (item.1.skipped is undefined or not item.1.skipped)
+      and item.0.wp.db_import is defined
+      and item.0.wp.db_import.path is defined
+      and item.1.stat.path == item.0.wp.db_import.path
+      and item.1.stat.exists
     with_nested:
       - "{{ domains }}"
       - "{{ import_src_paths.results }}"
@@ -27,7 +35,12 @@
     command: wp db reset --yes
     args:
       chdir: /home/{{ remote_web_user }}/www/{{ item.0.name }}
-    when: item.0.wp.db-import is defined and item.0.wp.db_import.path is defined and item.1.stat.path == item.0.wp.db_import.path and item.1.stat.exists
+    when: >
+      (item.1.skipped is undefined or not item.1.skipped)
+      and item.0.wp.db_import is defined
+      and item.0.wp.db_import.path is defined
+      and item.1.stat.path == item.0.wp.db_import.path
+      and item.1.stat.exists
     with_nested:
       - "{{ domains }}"
       - "{{ import_src_paths.results }}"
@@ -36,7 +49,12 @@
     command: wp db import import.sql
     args:
       chdir: /home/{{ remote_web_user }}/www/{{ item.0.name }}
-    when: item.0.wp.db-import is defined and item.0.wp.db_import.path is defined and item.1.stat.path == item.0.wp.db_import.path and item.1.stat.exists
+    when: >
+      (item.1.skipped is undefined or not item.1.skipped)
+      and item.0.wp.db_import is defined
+      and item.0.wp.db_import.path is defined
+      and item.1.stat.path == item.0.wp.db_import.path
+      and item.1.stat.exists
     with_nested:
       - "{{ domains }}"
       - "{{ import_src_paths.results }}"
@@ -46,7 +64,11 @@
       dest: /home/{{ remote_web_user }}/www/{{ item.name }}/wp-config.php
       regexp: '(table_prefix = .)wp_(.;)'
       replace: '\1{{ item.wp.db_import.db_prefix | default("wp_") }}\2'
-    when: item.wp.db-import is defined and item.wp.db_import.path
+    when: >
+      item.wp.db_import is defined
+      and item.wp.db_import.path
+      and (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
+      and item.name not in domains_to_skip
     with_items:
       - "{{ domains }}"
 
@@ -54,7 +76,12 @@
     command: wp search-replace '{{ item.wp.db_import.search_replace_domain }}' '{{ item.scheme | default('http://' }}{{ item.name }}'
     args:
       chdir: /home/{{ remote_web_user }}/www/{{ item.name }}
-    when: item.wp.db_import.search_replace_domain is defined  and item.wp.db_import.search_replace_domain != item.name
+    when: >
+      item.wp.db_import is defined
+      and item.wp.db_import.search_replace_domain is defined
+      and item.wp.db_import.search_replace_domain != item.name
+      and (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
+      and item.name not in domains_to_skip
     with_items:
       - "{{ domains }}"
 
@@ -62,7 +89,11 @@
     command: wp search-replace '{{ item.wp.db_import.search_replace_path }}' '/home/{{ remote_web_user }}/www/{{ item.name }}'
     args:
       chdir: /home/{{ remote_web_user }}/www/{{ item.name }}
-    when: item.wp.db_import.search_replace_path is defined
+    when: >
+      item.wp.db_import is defined
+      and item.wp.db_import.search_replace_path is defined
+      and (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
+      and item.name not in domains_to_skip
     with_items:
       - "{{ domains }}"
 

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -15,6 +15,9 @@
   args:
     creates: /etc/letsencrypt/live/{{ item.name }}
   notify: restart nginx
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
+    and item.name not in domains_to_skip
   with_items:
     - "{{ domains }}"
 
@@ -22,6 +25,9 @@
   file:
     path: /etc/nginx/sites-enabled/{{ item.name }}.nonssl.conf
     state: absent
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
+    and item.name not in domains_to_skip
   with_items:
     - "{{ domains }}"
 
@@ -31,6 +37,9 @@
     dest: /etc/nginx/sites-enabled/{{ item.name }}.ssl.conf
     state: link
   notify: restart nginx
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
+    and item.name not in domains_to_skip
   with_items:
     - "{{ domains }}"
 
@@ -39,5 +48,8 @@
     name: letsencrypt_renewal_{{ item.name }}
     special_time: weekly
     job: letsencrypt --renew certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ item.name }} && service nginx reload
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
+    and item.name not in domains_to_skip
   with_items:
     - "{{ domains }}"

--- a/roles/nginxsites/tasks/main.yml
+++ b/roles/nginxsites/tasks/main.yml
@@ -7,6 +7,9 @@
     src: "{{ item.1.src }}"
     dest: "{{ nginx_defaults.file_path }}/{{ item.0.name }}.{{ item.1.type }}.conf"
     force: no
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
+    and item.0.name not in domains_to_skip
   with_nested:
     - "{{ domains }}"
     - "{{ nginx_defaults.single_wp_site }}"
@@ -16,6 +19,9 @@
     dest: "{{ nginx_defaults.file_path }}/{{ item.0.name }}.{{ item.1.type }}.conf"
     regexp: "{{ item.1.root_path_regex }}"
     replace: '\1/home/{{ remote_web_user }}/www/{{ item.0.name }}\2'
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
+    and item.0.name not in domains_to_skip
   with_nested:
     - "{{ domains }}"
     - "{{ nginx_defaults.single_wp_site }}"
@@ -25,6 +31,9 @@
     path: "{{ nginx_defaults.file_path }}/{{ item.0.name }}.{{ item.1.type }}.conf"
     regexp: "{{ item.1.domain_regex }}"
     replace: '\1{{ item.0.name }}\2'
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
+    and item.0.name not in domains_to_skip
   with_nested:
     - "{{ domains }}"
     - "{{ nginx_defaults.single_wp_site }}"
@@ -35,6 +44,9 @@
     path: "{{ nginx_defaults.file_path }}/{{ item.0.name }}.{{ item.1.type }}.conf"
     regexp: "{{ nginx_defaults.letsencrypt_regex }}"
     replace: '\1/home/{{ remote_web_user }}/www/letsencrypt\2'
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
+    and item.0.name not in domains_to_skip
   with_nested:
     - "{{ domains }}"
     - "{{ nginx_defaults.single_wp_site }}"
@@ -46,6 +58,9 @@
     regexp: "access_log"
     line: "access_log /home/{{ remote_web_user }}/www/{{ item.0.name }}/logs/access.log;"
     state: present
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
+    and item.0.name not in domains_to_skip
   with_nested:
     - "{{ domains }}"
     - "{{ nginx_defaults.single_wp_site }}"
@@ -58,6 +73,9 @@
     regexp: "error_log"
     line: "error_log /home/{{ remote_web_user }}/www/{{ item.0.name }}/logs/error.log;"
     state: present
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
+    and item.0.name not in domains_to_skip
   with_nested:
     - "{{ domains }}"
     - "{{ nginx_defaults.single_wp_site }}"
@@ -67,6 +85,9 @@
   register: ssl_symlink_exists
   stat:
     path: "{{ nginx_defaults.file_path_enabled }}/{{ item.name }}.{{ nginx_defaults.ssl_ext }}"
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
+    and item.name not in domains_to_skip
   with_items:
     - "{{ domains }}"
 
@@ -77,7 +98,10 @@
     dest: "{{ nginx_defaults.file_path_enabled }}/{{ item.0.name }}.{{ nginx_defaults.non_ssl_ext }}"
     state: link
   notify: restart nginx
-  when: 'nginx_defaults.file_path_enabled+"/"+item.0.name+"."+nginx_defaults.ssl_ext == item.1.invocation.module_args.path and not item.1.stat.exists'
+  when: >
+    (item.1.skipped is undefined or not item.1.skipped)
+    and nginx_defaults.file_path_enabled+"/"+item.0.name+"."+nginx_defaults.ssl_ext == item.1.invocation.module_args.path
+    and not item.1.stat.exists
   with_nested:
     - "{{ domains }}"
     - "{{ ssl_symlink_exists.results }}"

--- a/roles/wordpress/tasks/main.yml
+++ b/roles/wordpress/tasks/main.yml
@@ -2,6 +2,9 @@
 - name: Generate random password for wp db user
   command: php -r "echo md5(random_bytes(10));"
   register: db_pass
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
+    and item.name not in domains_to_skip
   with_items:
     - "{{ domains }}"
 
@@ -9,6 +12,9 @@
   mysql_db:
     name: '{{ item.wp.db_name }}'
     state: present
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
+    and item.name not in domains_to_skip
   with_items:
     - "{{ domains }}"
 
@@ -20,6 +26,8 @@
     host: localhost
     state: present
     update_password: on_create
+  when: >
+    (item.1.skipped is undefined or not item.1.skipped)
   with_together:
     - "{{ domains }}"
     - "{{ db_pass.results }}"
@@ -29,6 +37,9 @@
     file:
       path: '/home/{{ remote_web_user }}/www/{{ item.name }}'
       state: directory
+    when: >
+      (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
+      and item.name not in domains_to_skip
     with_items:
       - "{{ domains }}"
 
@@ -36,6 +47,9 @@
     file:
       path: '/home/{{ remote_web_user }}/www/{{ item.name }}/logs'
       state: directory
+    when: >
+      (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
+      and item.name not in domains_to_skip
     with_items:
       - "{{ domains }}"
 
@@ -43,6 +57,9 @@
   - name: Is WordPress already downloaded
     stat: path=/home/{{ remote_web_user }}/www/{{ item.name }}/wp-load.php
     register: wp_downloaded
+    when: >
+      (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
+      and item.name not in domains_to_skip
     with_items:
       - "{{ domains }}"
 
@@ -50,7 +67,9 @@
     command: wp core download
     args:
       chdir: '/home/{{ remote_web_user }}/www/{{ item.0.name }}'
-    when: not item.1.stat.exists
+    when: >
+      (item.1.skipped is undefined or not item.1.skipped)
+      and not item.1.stat.exists
     with_together:
       - "{{ domains }}"
       - "{{ wp_downloaded.results }}"
@@ -58,6 +77,9 @@
   - name: Is WordPress config already setup
     stat: path=/home/{{ remote_web_user }}/www/{{ item.name }}/wp-config.php
     register: wp_configured
+    when: >
+      (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
+      and item.name not in domains_to_skip
     with_items:
       - "{{ domains }}"
 
@@ -65,7 +87,9 @@
     command: wp config create --dbname={{ item.0.wp.db_name|quote }} --dbuser={{ item.0.wp.db_name|quote }} --dbpass={{item.2.stdout|quote}}
     args:
       chdir: '/home/{{ remote_web_user }}/www/{{ item.0.name }}'
-    when: not item.1.stat.exists
+    when: >
+      (item.1.skipped is undefined or not item.1.skipped)
+      and not item.1.stat.exists
     with_together:
       - "{{ domains }}"
       - "{{ wp_configured.results }}"
@@ -76,6 +100,9 @@
     args:
       chdir: '/home/{{ remote_web_user }}/www/{{ item.name }}'
     register: wp_installed
+    when: >
+      (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
+      and item.name not in domains_to_skip
     with_items:
      - "{{ domains }}"
 
@@ -83,7 +110,10 @@
     command: wp core install --url={{ item.0.name|quote }} --title={{ item.0.wp.site_title|quote }} --admin_user={{ item.0.wp.admin_user|quote }} --admin_password={{ item.0.wp.admin_pass|quote }} --admin_email={{ item.0.wp.admin_email|quote }}
     args:
       chdir: '/home/{{ remote_web_user }}/www/{{ item.0.name }}'
-    when: "'Error:' not in item.1.stderr and item.1.rc != 0"
+    when: >
+      (item.1.skipped is undefined or not item.1.skipped)
+      and 'Error:' not in item.1.stderr
+      and item.1.rc != 0
     with_together:
      - "{{ domains }}"
      - "{{ wp_installed.results }}"


### PR DESCRIPTION
See #15.  This implements the ability to use `include_domains` or `exclude_domains` extra vars at the command line to execute the playbook only on specific site configurations attached to the named domains within the `vars.yml` file.

Example:

```
ansible-playbook playbook.yml -e "include_domains=testc.domain.comd,testd.domain.com"
```