### PR TITLE
add plugin development deploy roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The following roles are in this playbook.
 | geerlingguy.composer | adds composer to the server | composer
 | geerlingguy.redis | adds redis to the server |  redis
 | php-redis | adds the php7.1 module for redis to the server | redis
+| buildmachine.webhook.listener | Sets up the [webhook listener](https://github.com/nerrad/buildmachine-webhook-listener) for the Grunt Buildmachine for WordPress plugins | webhook, buildmachine
+| grunt-buildmachine | Sets up the [Grunt Buildmachine for WordPress Plugins](https://github.com/eventespresso/grunt-wp-plugin-buildmachine) service. | buildmachine, gruntbm
 
 ## Usage
 

--- a/playbook.yml
+++ b/playbook.yml
@@ -73,6 +73,8 @@
      role: php-redis
      tags: [redis]
     -
+     role: buildmachine.webhook.listener
+     tags: [buildmachine, webhook]
     -
      role: postrun.message
      tags:

--- a/playbook.yml
+++ b/playbook.yml
@@ -11,6 +11,7 @@
     domains_to_use: "{{ domuse.split(',') }}"
     domskip: "{{ skip_domains | default('none') }}"
     domains_to_skip: "{{ domskip.split(',') }}"
+    post_run_messages: []
   vars_files:
     - vars.yml
   remote_user: "{{ remote_sudo_user }}"
@@ -71,3 +72,8 @@
     -
      role: php-redis
      tags: [redis]
+    -
+    -
+     role: postrun.message
+     tags:
+      - always

--- a/playbook.yml
+++ b/playbook.yml
@@ -76,6 +76,9 @@
      role: buildmachine.webhook.listener
      tags: [buildmachine, webhook]
     -
+     role: grunt-buildmachine
+     tags: [buildmachine, gruntbm]
+    -
      role: postrun.message
      tags:
       - always

--- a/roles/buildmachine.webhook.listener/defaults/main.yml
+++ b/roles/buildmachine.webhook.listener/defaults/main.yml
@@ -1,0 +1,1 @@
+default_buildmachine_map_path: /home/{{ remote_web_user }}/buildmachine/installedReposMap.json

--- a/roles/buildmachine.webhook.listener/meta/main.yml
+++ b/roles/buildmachine.webhook.listener/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - { role: nginx }
+  - { role: geerlingguy.composer }

--- a/roles/buildmachine.webhook.listener/tasks/main.yml
+++ b/roles/buildmachine.webhook.listener/tasks/main.yml
@@ -1,0 +1,135 @@
+---
+# This role will setup an instance of the Grunt Buildmachine Webhook Listener
+# including:
+# - nginx configuration
+# - clone to directory
+# - ssl
+# - setup configuration file from provided parameters (see vars-sample.yml)
+# - generate a random string to use as the token for the webhook.
+
+- name: Create nginx configurations
+  template:
+    src: "{{ item.file }}"
+    dest: /etc/nginx/sites-available/{{ webhook.domain }}.{{ item.type }}.conf
+    mode: 0644
+  when: webhook is defined and webhook.domain is defined
+  with_items:
+    - { file: nginx-nonssl.j2, type: nonssl }
+    - { file: nginx-ssl.j2, type: ssl }
+
+- name: Verify whether ssl_symlink_exists
+  register: webhook_ssl_symlink_exists
+  stat:
+    path: /etc/nginx/sites-enabled/{{ webhook.domain }}.ssl.conf
+  when: webhook is defined and webhook.domain is defined
+
+- name: Symlink non-ssl nginx config (but only if ssl configuration symlink doesn't exist)
+  file:
+    src: /etc/nginx/sites-available/{{ webhook.domain }}.nonssl.conf
+    dest: /etc/nginx/sites-enabled/{{ webhook.domain }}.nonssl.conf
+    state: link
+  notify: restart nginx
+  when: >
+    webhook is defined and webhook.domain is defined
+    and not webhook_ssl_symlink_exists.stat.exists
+
+- block: #switch to webuser
+  - name: Generate random string for token key
+    command: php -r "echo md5(random_bytes(10));"
+    register: webhook_token
+    when: webhook is defined and webhook.domain is defined
+
+  - name: Create directory for webhook
+    file:
+      path: /home/{{ remote_web_user }}/www/{{ webhook.domain }}/public
+      state: directory
+    when: webhook is defined and webhook.domain is defined
+
+  - name: Create directories for nginx logs #check permissions and what user the directories are created with
+    file:
+      path: /home/{{ remote_web_user }}/www/{{ webhook.domain }}/logs
+      state: directory
+    when: webhook is defined and webhook.domain is defined
+
+  - name: Does webhook repo git checkout already exist?
+    stat:
+      path: /home/{{ remote_web_user }}/www/{{ webhook.domain }}/public/.git
+    register: webhook_git_exists
+
+  - name: Clone in webhook repository
+    git:
+      repo: https://github.com/nerrad/buildmachine-webhook-listener.git
+      dest: /home/{{ remote_web_user }}/www/{{ webhook.domain }}/public
+      version: master
+      force: yes
+    when: >
+      webhook is defined
+      and webhook.domain is defined
+      and not webhook_git_exists.stat.exists
+
+  - name: Run composer install on webhook service
+    composer:
+      command: install
+      working_dir: /home/{{ remote_web_user }}/www/{{ webhook.domain }}/public
+    when: >
+      webhook is defined
+      and webhook.domain is defined
+      and not webhook_git_exists.stat.exists
+
+  - name: Setup configuration file for webhook service
+    template:
+      src: app-config.j2
+      dest: /home/{{ remote_web_user }}/www/{{ webhook.domain }}/public/app-config.php
+      mode: 0664
+    when: >
+      webhook is defined
+      and webhook.domain is defined
+      and webhook.server_git_email is defined
+
+  become: true
+  become_user: "{{ remote_web_user }}"
+
+- name: create letsencrypt folder for cert verification
+  file:
+    name: /home/{{ remote_web_user }}/www/letsencrypt
+    state: directory
+
+- name: force restart nginx
+  service:
+    name: nginx
+    state: restarted
+  become: yes
+
+- name: Create letsencrypt cert
+  shell: letsencrypt certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ webhook.domain }}
+  args:
+    creates: /etc/letsencrypt/live/{{ webhook.domain }}
+  notify: restart nginx
+  when: webhook is defined and webhook.domain is defined
+
+- name: remove symlink for non-ssl
+  file:
+    path: /etc/nginx/sites-enabled/{{ webhook.domain }}.nonssl.conf
+    state: absent
+  when: webhook is defined and webhook.domain is defined
+
+- name: copy symlink for ssl
+  file:
+    src: /etc/nginx/sites-available/{{ webhook.domain }}.ssl.conf
+    dest: /etc/nginx/sites-enabled/{{ webhook.domain }}.ssl.conf
+    state: link
+  notify: restart nginx
+  when: webhook is defined and webhook.domain is defined
+
+- name: setup cron job for cert renewal
+  cron:
+    name: letsencrypt_renewal_{{ webhook.domain }}
+    special_time: weekly
+    job: letsencrypt --renew certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ webhook.domain }} && service nginx reload
+  when: webhook is defined and webhook.domain is defined
+
+- name: Add message to post_run_messages with webhook.
+  set_fact:
+    post_run_messages: "{{ post_run_messages }}
+      + ['Webhook installed and available at: https://{{ webhook.domain }}/?token={{ webhook_token.stdout }}']"
+  when: webhook is defined and webhook.domain is defined

--- a/roles/buildmachine.webhook.listener/templates/app-config.j2
+++ b/roles/buildmachine.webhook.listener/templates/app-config.j2
@@ -1,0 +1,7 @@
+<?php
+$repository_type = '{{ webhook.repo_type|default('github') }}';
+$server_git_email = '{{ webhook.server_git_email }}';
+$access_token = '{{ webhook_token.stdout }}';
+$grunt_path = '{{ webhook.grunt_path|default('~/buildmachine') }}';
+$grunt_src_path = '{{ webhook.grunt_src_path|default('~/buildmachine/buildsrc/') }}';
+$map_file = '{{ webhook.map_file|default(default_buildmachine_map_path) }}';

--- a/roles/buildmachine.webhook.listener/templates/nginx-nonssl.j2
+++ b/roles/buildmachine.webhook.listener/templates/nginx-nonssl.j2
@@ -1,0 +1,40 @@
+#######################
+# nonssl nginx.conf for {{ webhook.domain }}
+######################
+
+#unsecured listener
+server {
+    listen      80;
+    listen      [::]:80;
+    server_name     {{ webhook.domain }};
+    root /home/{{ remote_web_user }}/www/{{ webhook.domain }}/public;
+
+    # File to be used as index
+    index index.php;
+
+    #site specific access logs
+    access_log /home/{{ remote_web_user }}/www/{{ webhook.domain }}/logs/access.log;
+    error_log /home/{{ remote_web_user }}/www/{{ webhook.domain }}/logs/error.log;
+
+    # Default server block rules
+    include global/server/defaults.conf;
+
+    # LetsEncrypt acme-challenge
+    location ^~ /.well-known/acme-challenge {
+        root /home/{{ remote_web_user }}/www/letsencrypt;
+        try_files $uri $uri/ =404;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.php?$args;
+    }
+
+    location ~\.php$ {
+        try_files       $uri =404;
+        include         global/fastcgi-params.conf;
+        fastcgi_read_timeout 6000;
+        fastcgi_buffer_size 512k;
+        fastcgi_buffers 4 512k;
+        fastcgi_pass    $upstream;
+    }
+}

--- a/roles/buildmachine.webhook.listener/templates/nginx-ssl.j2
+++ b/roles/buildmachine.webhook.listener/templates/nginx-ssl.j2
@@ -1,0 +1,55 @@
+#######################
+# ssl nginx.conf for {{ webhook.domain }}
+######################
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name     {{ webhook.domain }};
+    root            /home/{{ remote_web_user }}/www/{{ webhook.domain }}/public;
+
+    # Paths to certificate files.
+    ssl_certificate /etc/letsencrypt/live/{{ webhook.domain }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ webhook.domain }}/privkey.pem;
+
+    # File to be used as index
+    index index.php;
+
+    #site specific access logs
+    access_log /home/{{ remote_web_user }}/www/{{ webhook.domain }}/logs/access.log;
+    error_log /home/{{ remote_web_user }}/www/{{ webhook.domain }}/logs/error.log;
+
+    # Default server block rules
+    include global/server/defaults.conf;
+
+    # SSL rules
+    include global/server/ssl.conf;
+
+    # LetsEncrypt acme-challenge (need to keep for renewals)
+    location ^~ /.well-known/acme-challenge {
+        root /home/{{ remote_web_user }}/www/letsencrypt;
+        try_files $uri $uri/ =404;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.php?$args;
+    }
+
+    location ~\.php$ {
+        try_files       $uri =404;
+        include         global/fastcgi-params.conf;
+        fastcgi_read_timeout 6000;
+        fastcgi_buffer_size 512k;
+        fastcgi_buffers 4 512k;
+        fastcgi_pass    $upstream;
+    }
+}
+
+# Redirect http to https
+server {
+	listen 80;
+	listen [::]:80;
+	server_name {{ webhook.domain }};
+
+	return 301 https://{{ webhook.domain }}$request_uri;
+}

--- a/roles/gitdeploy/defaults/main.yml
+++ b/roles/gitdeploy/defaults/main.yml
@@ -1,0 +1,1 @@
+post_run_domain_push_reminder: []

--- a/roles/gitdeploy/tasks/main.yml
+++ b/roles/gitdeploy/tasks/main.yml
@@ -129,5 +129,21 @@
       - "{{ domains }}"
       - "{{ remote_set.results }}"
 
+  - name: followup message for domains
+    set_fact:
+      post_run_domain_push_reminder: >
+        {{ post_run_domain_push_reminder }}
+        + ['    {{ item.0.name }}: ssh://{{ remote_web_user }}@{{ ansible_default_ipv4.address }}/~/{{ item.0.git_deploy.hubdirectory}}']
+    when: >
+      (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
+      and item.name not in domains_to_skip
+      and item.git_deploy is defined
+      and item.git_deploy.hubdirectory is defined
+
+  - name: followup message prefix
+    set_fact:
+      post_run_messages: "{{ post_run_messages }} + ['Now you have add the server as a remote and push the first commits for the following sites and domains:']"
+    when: post_run_domain_push_reminder|length > 0
+
   become: true
   become_user: "{{ remote_web_user }}"

--- a/roles/gitdeploy/tasks/main.yml
+++ b/roles/gitdeploy/tasks/main.yml
@@ -131,9 +131,8 @@
 
   - name: followup message for domains
     set_fact:
-      post_run_domain_push_reminder: >
-        {{ post_run_domain_push_reminder }}
-        + ['    {{ item.0.name }}: ssh://{{ remote_web_user }}@{{ ansible_default_ipv4.address }}/~/{{ item.0.git_deploy.hubdirectory}}']
+      post_run_domain_push_reminder: "{{ post_run_domain_push_reminder }}
+        + ['    {{ item.0.name }}: ssh://{{ remote_web_user }}@{{ ansible_default_ipv4.address }}/~/{{ item.0.git_deploy.hubdirectory}}']"
     when: >
       (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
       and item.name not in domains_to_skip
@@ -142,7 +141,8 @@
 
   - name: followup message prefix
     set_fact:
-      post_run_messages: "{{ post_run_messages }} + ['Now you have add the server as a remote and push the first commits for the following sites and domains:']"
+      post_run_messages: "{{ post_run_messages }}
+        + ['Now you have to add the server as a remote and push the first commits for the following sites and domains:']"
     when: post_run_domain_push_reminder|length > 0
 
   become: true

--- a/roles/grunt-buildmachine/meta/main.yml
+++ b/roles/grunt-buildmachine/meta/main.yml
@@ -1,0 +1,5 @@
+---
+dependencies:
+ - { role: nginx }
+ - { role: geerlingguy.nodejs }
+ - { role: grunt }

--- a/roles/grunt-buildmachine/tasks/main.yml
+++ b/roles/grunt-buildmachine/tasks/main.yml
@@ -1,0 +1,180 @@
+---
+# This role will setup an instance of the Grunt Buildmachine for WordPress plugins
+# including:
+# - nginx configuration for the url providing access to built zips (protected by basic auth)
+# - ssl for the above
+# - install the buildmachine at the root folder of the web user and configured according to parameters provided in
+#   vars.yml
+- name: Create nginx configurations
+  template:
+    src: "{{ item.file }}"
+    dest: /etc/nginx/sites-available/{{ buildmachine.build_creds.archiveDomain }}.{{ item.type }}.conf
+    mode: 0644
+  when: >
+    buildmachine is defined
+    and buildmachine.build_creds is defined
+    and buildmachine.build_creds.archiveDomain is defined
+  with_items:
+    - { file: nginx-nonssl.j2, type: nonssl }
+    - { file: nginx-ssl.j2, type: ssl }
+
+- name: Verify whether ssl_symlink_exists
+  register: buildmachine_ssl_symlink_exists
+  stat:
+    path: /etc/nginx/sites-enabled/{{ buildmachine.build_creds.archiveDomain }}.ssl.conf
+  when: >
+    buildmachine is defined
+    and buildmachine.build_creds is defined
+    and buildmachine.build_creds.archiveDomain is defined
+
+- name: Symlink non-ssl nginx config (but only if ssl configuration symlink doesn't exist)
+  file:
+    src: /etc/nginx/sites-available/{{ buildmachine.build_creds.archiveDomain }}.nonssl.conf
+    dest: /etc/nginx/sites-enabled/{{ buildmachine.build_creds.archiveDomain }}.nonssl.conf
+    state: link
+  notify: restart nginx
+  when: >
+    buildmachine is defined
+    and buildmachine.build_creds is defined
+    and buildmachine.build_creds.archiveDomain is defined
+    and not buildmachine_ssl_symlink_exists.stat.exists
+
+- name: Does .htpasswd file already exist?  If it does don't overwrite it.
+  register: buildmachine_htpasswd_exists
+  stat:
+    path: /etc/nginx/.htpasswd
+
+- name: Generate .htpasswd file for restricting build url to basic auth.
+  shell: |
+    echo -n '{{ buildmachine.build_creds.archiveUser | quote }}:' >> /etc/nginx/.htpasswd
+    echo '{{ buildmachine.build_creds.archivePass | quote }}' | openssl passwd -apr1 -stdin >> /etc/nginx/.htpasswd
+  when: >
+    not buildmachine_htpasswd_exists.stat.exists
+    and buildmachine is defined
+    and buildmachine.build_creds is defined
+    and buildmachine.build_creds.archiveUser is defined
+    and buildmachine.build_creds.archivePass is defined
+
+- block: #switch to web user
+
+  - name: Create directory for buildmachine's build folder
+    file:
+      path: /home/{{ remote_web_user }}/www/{{ buildmachine.build_creds.archiveDomain }}/public
+      state: directory
+    when: >
+      buildmachine is defined
+      and buildmachine.build_creds is defined
+      and buildmachine.build_creds.archiveDomain is defined
+
+  - name: Create directories for nginx logs #check permissions and what user the directories are created with
+    file:
+      path: /home/{{ remote_web_user }}/www/{{ buildmachine.build_creds.archiveDomain }}/logs
+      state: directory
+    when: >
+      buildmachine is defined
+      and buildmachine.build_creds is defined
+      and buildmachine.build_creds.archiveDomain is defined
+
+  - name: Create directory for the buildmachine itself.
+    file:
+      path: /home/{{ remote_web_user }}/buildmachine
+      state: directory
+    when: >
+      buildmachine is defined
+
+  - name: Does buildmachine repo git checkout already exist?
+    stat:
+      path: /home/{{ remote_web_user }}/buildmachine/.git
+    register: buildmachine_git_exists
+
+  - name: Clone in buildmachine repository
+    git:
+      repo: https://github.com/eventespresso/grunt-wp-plugin-buildmachine.git
+      dest: /home/{{ remote_web_user }}/buildmachine
+      version: master
+      force: yes
+    when: >
+      buildmachine is defined
+      and not buildmachine_git_exists.stat.exists
+
+  - name: Run npm install on buildmachine service
+    npm:
+      path: /home/{{ remote_web_user }}/buildmachine
+    when: >
+      buildmachine is defined
+      and not buildmachine_git_exists.stat.exists
+
+  - name: Setup configuration file for buildmachine service
+    template:
+      src: private.j2
+      dest: /home/{{ remote_web_user }}/buildmachine/private.json
+      mode: 0664
+    when: >
+      buildmachine is defined
+      and buildmachine.build_creds is defined
+      and buildmachine.build_creds.archiveUser is defined
+      and buildmachine.build_creds.archivePass is defined
+      and buildmachine.parentPluginSlug is defined
+
+  become: true
+  become_user: "{{ remote_web_user }}"
+
+- name: create letsencrypt folder for cert verification
+  file:
+    name: /home/{{ remote_web_user }}/www/letsencrypt
+    state: directory
+
+- name: force restart nginx
+  service:
+    name: nginx
+    state: restarted
+  become: yes
+
+- name: Create letsencrypt cert
+  shell: letsencrypt certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ buildmachine.build_creds.archiveDomain }}
+  args:
+    creates: /etc/letsencrypt/live/{{ buildmachine.build_creds.archiveDomain }}
+  notify: restart nginx
+  when: >
+    buildmachine is defined
+    and buildmachine.build_creds is defined
+    and buildmachine.build_creds.archiveDomain is defined
+
+- name: remove symlink for non-ssl
+  file:
+    path: /etc/nginx/sites-enabled/{{ buildmachine.build_creds.archiveDomain }}.nonssl.conf
+    state: absent
+  when: >
+    buildmachine is defined
+    and buildmachine.build_creds is defined
+    and buildmachine.build_creds.archiveDomain is defined
+
+- name: copy symlink for ssl
+  file:
+    src: /etc/nginx/sites-available/{{ buildmachine.build_creds.archiveDomain }}.ssl.conf
+    dest: /etc/nginx/sites-enabled/{{ buildmachine.build_creds.archiveDomain }}.ssl.conf
+    state: link
+  notify: restart nginx
+  when: >
+    buildmachine is defined
+    and buildmachine.build_creds is defined
+    and buildmachine.build_creds.archiveDomain is defined
+
+- name: setup cron job for cert renewal
+  cron:
+    name: letsencrypt_renewal_{{ buildmachine.build_creds.archiveDomain }}
+    special_time: weekly
+    job: letsencrypt --renew certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ buildmachine.build_creds.archiveDomain }} && service nginx reload
+  when: >
+    buildmachine is defined
+    and buildmachine.build_creds is defined
+    and buildmachine.build_creds.archiveDomain is defined
+
+- name: Add message to post_run_messages with webhook.
+  set_fact:
+    post_run_messages: "{{ post_run_messages }}
+      + ['Buildmachine installed and available on the server. Make sure you visit https://github.com/eventespresso/grunt-wp-plugin-buildmachine for instructions on how to finish setting things up.']"
+  when: >
+    buildmachine is defined
+    and buildmachine.build_creds is defined
+    and buildmachine.build_creds.archiveDomain is defined

--- a/roles/grunt-buildmachine/templates/nginx-nonssl.j2
+++ b/roles/grunt-buildmachine/templates/nginx-nonssl.j2
@@ -1,0 +1,32 @@
+#######################
+# nonssl nginx.conf for {{ buildmachine.build_creds.archiveDomain }}
+######################
+
+#unsecured listener
+server {
+    listen      80;
+    listen      [::]:80;
+    server_name     {{ buildmachine.build_creds.archiveDomain }};
+    root /home/{{ remote_web_user }}/www/{{ buildmachine.build_creds.archiveDomain }}/public;
+
+    # File to be used as index
+    index index.html;
+
+    #site specific access logs
+    access_log /home/{{ remote_web_user }}/www/{{ webhook.domain }}/logs/access.log;
+    error_log /home/{{ remote_web_user }}/www/{{ webhook.domain }}/logs/error.log;
+
+    # Default server block rules
+    include global/server/defaults.conf;
+
+    # LetsEncrypt acme-challenge
+    location ^~ /.well-known/acme-challenge {
+        root /home/{{ remote_web_user }}/www/letsencrypt;
+        try_files $uri $uri/ =404;
+    }
+
+    location ~ \.zip$ {
+        auth_basic "Authorization Required";
+        auth_basic_user_file /etc/nginx/.htpasswd;
+    }
+}

--- a/roles/grunt-buildmachine/templates/nginx-ssl.j2
+++ b/roles/grunt-buildmachine/templates/nginx-ssl.j2
@@ -1,0 +1,47 @@
+#######################
+# ssl nginx.conf for {{ buildmachine.build_creds.archiveDomain }}
+######################
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name     {{ buildmachine.build_creds.archiveDomain }};
+    root            /home/{{ remote_web_user }}/www/{{ buildmachine.build_creds.archiveDomain }}/public;
+
+    # Paths to certificate files.
+    ssl_certificate /etc/letsencrypt/live/{{ buildmachine.build_creds.archiveDomain }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ buildmachine.build_creds.archiveDomain }}/privkey.pem;
+
+    # File to be used as index
+    index index.html;
+
+    #site specific access logs
+    access_log /home/{{ remote_web_user }}/www/{{ buildmachine.build_creds.archiveDomain }}/logs/access.log;
+    error_log /home/{{ remote_web_user }}/www/{{ buildmachine.build_creds.archiveDomain }}/logs/error.log;
+
+    # Default server block rules
+    include global/server/defaults.conf;
+
+    # SSL rules
+    include global/server/ssl.conf;
+
+    # LetsEncrypt acme-challenge (need to keep for renewals)
+    location ^~ /.well-known/acme-challenge {
+        root /home/{{ remote_web_user }}/www/letsencrypt;
+        try_files $uri $uri/ =404;
+    }
+
+    location ~ \.zip$ {
+        auth_basic "Authorization Required";
+        auth_basic_user_file /etc/nginx/.htpasswd;
+    }
+}
+
+# Redirect http to https
+server {
+	listen 80;
+	listen [::]:80;
+	server_name {{ buildmachine.build_creds.archiveDomain }};
+
+	return 301 https://{{ buildmachine.build_creds.archiveDomain }}$request_uri;
+}

--- a/roles/grunt-buildmachine/templates/private.j2
+++ b/roles/grunt-buildmachine/templates/private.j2
@@ -1,0 +1,35 @@
+{
+    {% if buildmachine.parentPluginSlug is defined %}
+    "parentPluginSlug" : "{{ buildmachine.parentPluginSlug }}"
+    {% endif %}
+    "build_creds" : {
+        "archiveUser" : "{{ buildmachine.build_creds.archiveUser }}",
+        "archivePass" : "{{ buildmachine.build_creds.archivePass }}",
+        "archiveDomain" : "https://{{ buildmachine.build_creds.archiveDomain }}",
+        "archiveBasePath" : "~/www/{{ buildmachine.build_creds.archiveDomain }}/public/"
+    {% if buildmachine.slack_creds is defined %}
+    },
+    "slack_creds" : {
+        "authToken" : "{{ buildmachine.slack_creds.authToken }}",
+        "botToken" : "{{ buildmachine.slack_creds.botToken }}",
+        "channels" : {
+            "build" : "{{ buildmachine.slack_creds.channels.build }}",
+            "main" : "{{ buildmachine.slack_creds.channels.main }}"
+        }
+    {% endif %}
+    {% if buildmachine.hipchat_creds is defined %}
+    },
+    "hipchat_creds" : {
+        "authToken" : "{{ buildmachine.hipchat_creds.authToken }}",
+        "roomID" : "{{ buildmachine.hipchat_creds.roomID }}"
+    {% endif %}
+    {% if buildmachine.version_meta is defined %}
+    },
+    "version_meta" : {
+        "preRelease" : "{{ buildmachine.version_meta.preRelease }}",
+        "decaf" : "{{ buildmachine.version_meta.decaf }}",
+        "rc" : "{{ buildmachine.version_meta.rc }}",
+        "release" : "{{ buildmachine.version_meta.release }}"
+    {% endif %}
+    }
+}

--- a/roles/postrun.message/tasks/main.yml
+++ b/roles/postrun.message/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+# Writes a post-run message to the user using the {{ post_install_messages }} variable
+# that can be pushed to by other plays.
+
+- name: Post Run Message Output
+  debug:
+    msg:
+      - "The following output was collected for you during this run:"
+      - "{{ post_run_messages }}"

--- a/vars-sample.yml
+++ b/vars-sample.yml
@@ -90,3 +90,32 @@ domains:
     git_deploy:
       hubdirectory: hub
       branch_deployed: master
+# The following variables are for the buildmachine-webhook role.  This role sets up a php webhook listener based off of
+# https://github.com/nerrad/buildmachine-webhook-listener.
+webhook:
+  # What will be the domain for this webhook. The role will configure nginx for this domain (including ssl) so make
+  # sure you have dns pointing to the server before running this role
+  domain: webhook.somedomain.com
+
+  # This represents the repository type that the webhook will listen for.  Current options are github or codebase.  The
+  # variable is optional and defaults to github.
+  repo_type: github
+
+  # This represents email address associated with the user doing git commits from the buildmachine.  The webhook
+  # listener will ignore any head commit notifications from git users with this email.
+  server_git_email: someemail@example.org
+
+  # This is the path on the server where your grunt build machine is configured. If you set up the grunt build-machine
+  # using its role in this playbook (default paths) then you don't need to configure this and just leave it undefined
+  # in your configuration
+  grunt_path: /path/to/grunt/build-machine/on/server
+
+  # This is the path to the source files of the plugins the grunt build-machine executes on.  Again, if you set up the
+  # grunt build-machine using its role in this playbook you don't need to configure this and just leave it undefined
+  # in your configuration
+  grunt_src_path: /path/to/grunt/build-machine/on/server/buildsrc/
+
+  # This is the path to the build-machine installed repositories map json file.   Again, if you set up the
+  # grunt build-machine using its role in this playbook you don't need to configure this and just leave it undefined
+  # in your configuration
+  map_file: /path/to/grunt/build-machine/on/server/installedReposMap.json

--- a/vars-sample.yml
+++ b/vars-sample.yml
@@ -90,6 +90,8 @@ domains:
     git_deploy:
       hubdirectory: hub
       branch_deployed: master
+
+# -- Webhook Listener for Grunt Build Machine triggers -- #
 # The following variables are for the buildmachine-webhook role.  This role sets up a php webhook listener based off of
 # https://github.com/nerrad/buildmachine-webhook-listener.
 webhook:
@@ -119,3 +121,54 @@ webhook:
   # grunt build-machine using its role in this playbook you don't need to configure this and just leave it undefined
   # in your configuration
   map_file: /path/to/grunt/build-machine/on/server/installedReposMap.json
+
+# -- grunt build machine for wordpress --#
+# The following variables are for the grunt-buildmachine role.  This role sets up an install of the "Grunt Build Machine
+# for WordPress Plugins" that is found at the following repository:
+# https://github.com/eventespresso/grunt-wp-plugin-buildmachine
+buildmachine:
+  # required, these are the various details surrounding the build directory where zips will be exposed at after a build.
+  build_creds:
+    # The build directory is protected by htpasswd, this is the htpasswd user.
+    archiveUser: htpasswduserforarchivebuilds
+    # This is what you want the htpasswd password to be for the build director.
+    archivePass: htpasswdpassforarchivebuilds
+    # This is what you want the domain for the build zips to be retrievable from.
+    # This will be setup with an ssl cert by letsencrypt so make sure your domain is pointing to the server this is
+    # setup on.
+    archiveDomain: urlpointingtoyourbuildpath.com
+  # optional.  You can provide credentials for slack notifications on successful build tasks.
+  slack_creds:
+    # This should be a user auth-token (prefixed by xoxp) and it can be generated at this url while logged in on your
+    # slack team: https://api.slack.com/custom-integrations/legacy-tokens
+    authToken: xoxp-xxxxxxxxxxx-xxxxxxxxxxxx-xxxxxxxxxx-xxxxxxxx
+    # Bot tokens are generated via the slack apps interface and are prefixed by xoxb.
+    botToken: xoxb-xxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxx
+    channels:
+      # This is the channel slug for where you want build notifications going.
+      build: "#buildnotification"
+      # This is the channel you want main notifications going.  Topic will also be changed in this channel for version
+      # bumps when text in the topic matches the following formats (on what is identified as the "parent plugin"):
+      # /REL:*.[0-9]\.[0-9]\.[0-9]+\.p/  -- release version numbers (where "p' is set to denote release versions
+      # /MASTR:*.[0-9]\.[0-9]\.[0-9]+\.rc\.[0-9]{3}/g -- release candidate version numbers (on master branch).
+      main: "#general"
+  # optional. You can provide credentials for hipchat notifications on successful build tasks.
+  hipchat_creds:
+    # go to yourdomain.hipchat.com/admin/api and obtain the authToken from there.
+    authToken: xxxxxxxxxxxxxxxxx
+    # id of the room to receive notifications (this would be where the topic is updates
+    roomID: 00000000
+  # optional. This is the version "indicators" used to represent various version types in the version string of builds. For any
+  # version meta string that you don't want used, just leave as an empty string.
+  version_meta:
+    # 4.2.4.beta
+    preRelease: beta
+    # 4.2.4.decaf - this is the version string used for wp.org releases
+    decaf: decaf
+    # 4.2.4.rc.000
+    rc: rc
+    # 4.2.4.p
+    release: p
+  # optional. This is the slug of the main plugin.  Currently this value is used to determine what builds trigger a topic change
+  # in the connected slack and/or hipchat rooms. If not provided, topics won't be updated in the notification channels.
+  parentPluginSlug: plugin-slug


### PR DESCRIPTION
This pull request:
- implements a role for setting messages to display to the user at the end of a run. 
- adds some messaging using the above in existing roles
- add new buildmachine.webhook.listener role.  Read more about this service [here](https://github.com/nerrad/buildmachine-webhook-listener)
- add new grunt-buildmachine role.  Read more about this service [here](https://github.com/eventespresso/grunt-wp-plugin-buildmachine)
- updated the README.md with the new roles.

With these new roles WordPress plugin developers can setup some tools for automating builds of their WordPress plugins.
