### PR TITLE
Expand support for WP MultiSite installations

### DIFF
--- a/roles/nginxsites/defaults/main.yml
+++ b/roles/nginxsites/defaults/main.yml
@@ -7,27 +7,27 @@ nginx_defaults:
   single_wp_site:
     - type: ssl
       src: /etc/nginx/sites-available/ssl.com
-      root_path_regex: '(\s)\/sites\/ssl\.com\/public(;)?$'
+      root_path_regex: '(\s)\/sites\/ssl\.com\/public(;)?'
       domain_regex: '(\s+|/|\.)ssl\.com(\s|/|\$|;)'
     - type: nonssl
       src: /etc/nginx/sites-available/singlesite.com
-      root_path_regex: '(\s)\/sites\/singlesite\.com\/public(;)?$'
+      root_path_regex: '(\s)\/sites\/singlesite\.com\/public(;)?'
       domain_regex: '(\s+|/|\.)singlesite\.com(\s|/|\$|;)'
   subdomain_multi_wp_site:
     - type: nonssl
       src: /etc/nginx/sites-available/multisite-subdomain.com
-      root_path_regex: '(\s)\/sites\/multisite-subdomain\.com\/public(;)?$'
+      root_path_regex: '(\s)\/sites\/multisite-subdomain\.com\/public(;)?'
       domain_regex: '(\s+|/|\.)multisite-subdomain\.com(\s|/|\$|;)'
     - type: ssl
       src: /etc/nginx/sites-available/ssl-multisite-subdomain.com
-      root_path_regex: '(\s)\/sites\/ssl-multisite-subdomain\.com\/public(;)?$'
+      root_path_regex: '(\s)\/sites\/ssl-multisite-subdomain\.com\/public(;)?'
       domain_regex: '(\s+|/|\.)ssl-multisite-subdomain\.com(\s|/|\$|;)'
   subdirectory_multi_wp_site:
     - type: nonssl
       src: /etc/nginx/sites-available/multisite-subdirectory.com
-      root_path_regex: '(\s)\/sites\/multisite-subdirectory\.com\/public(;)?$'
+      root_path_regex: '(\s)\/sites\/multisite-subdirectory\.com\/public(;)?'
       domain_regex: '(\s+|/|\.)multisite-subdirectory\.com(\s|/|\$|;)'
     - type: ssl
       src: /etc/nginx/sites-available/ssl-multisite-subdirectory.com
-      root_path_regex: '(\s)\/sites\/ssl-multisite-subdirectory\.com\/public(;)?$'
+      root_path_regex: '(\s)\/sites\/ssl-multisite-subdirectory\.com\/public(;)?'
       domain_regex: '(\s+|/|\.)ssl-multisite-subdirectory\.com(\s|/|\$|;)'

--- a/roles/nginxsites/defaults/main.yml
+++ b/roles/nginxsites/defaults/main.yml
@@ -13,14 +13,21 @@ nginx_defaults:
       src: /etc/nginx/sites-available/singlesite.com
       root_path_regex: '(\s)\/sites\/singlesite\.com\/public(;)?$'
       domain_regex: '(\s+|/|\.)singlesite\.com(\s|/|\$|;)'
-  multi_wp_site:
-    subdomain:
-        type: nonssl
-        src: /etc/nginx/sites-available/multisite-subdomain.com
-        root_path_regex: '(\s)\/sites\/multisite-subdomain\.com\/public(;)?$'
-        domain_regex: '(\s+|/|\.)multisite-subdomain\.com(\s|/|\$|;)'
-    subdirectory:
-        type: nonssl
-        src: /etc/nginx/sites-available/multisite-subdirectory.com
-        root_path_regex: '(\s)\/sites\/multisite-subdirectory\.com\/public(;)?$'
-        domain_regex: '(\s+|/|\.)multisite-subdirectory\.com(\s|/|\$|;)'
+  subdomain_multi_wp_site:
+    - type: nonssl
+      src: /etc/nginx/sites-available/multisite-subdomain.com
+      root_path_regex: '(\s)\/sites\/multisite-subdomain\.com\/public(;)?$'
+      domain_regex: '(\s+|/|\.)multisite-subdomain\.com(\s|/|\$|;)'
+    - type: ssl
+      src: /etc/nginx/sites-available/ssl-multisite-subdomain.com
+      root_path_regex: '(\s)\/sites\/ssl-multisite-subdomain\.com\/public(;)?$'
+      domain_regex: '(\s+|/|\.)ssl-multisite-subdomain\.com(\s|/|\$|;)'
+  subdirectory_multi_wp_site:
+    - type: nonssl
+      src: /etc/nginx/sites-available/multisite-subdirectory.com
+      root_path_regex: '(\s)\/sites\/multisite-subdirectory\.com\/public(;)?$'
+      domain_regex: '(\s+|/|\.)multisite-subdirectory\.com(\s|/|\$|;)'
+    - type: ssl
+      src: /etc/nginx/sites-available/ssl-multisite-subdirectory.com
+      root_path_regex: '(\s)\/sites\/ssl-multisite-subdirectory\.com\/public(;)?$'
+      domain_regex: '(\s+|/|\.)ssl-multisite-subdirectory\.com(\s|/|\$|;)'

--- a/roles/nginxsites/tasks/main.yml
+++ b/roles/nginxsites/tasks/main.yml
@@ -10,9 +10,43 @@
   when: >
     (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
     and item.0.name not in domains_to_skip
+    and (item.0.wp.install is undefined or item.0.wp.install == 'singlesite')
   with_nested:
     - "{{ domains }}"
     - "{{ nginx_defaults.single_wp_site }}"
+
+- name: Copy configurations to new domain based configuration. (for a sub-directory multisite install)
+  copy:
+    remote_src: yes
+    src: "{{ item.1.src }}"
+    dest: "{{ nginx_defaults.file_path }}/{{ item.0.name }}.{{ item.1.type }}.conf"
+    force: no
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
+    and item.0.name not in domains_to_skip
+    and item.0.wp.install is defined
+    and item.0.wp.install == 'multisite'
+    and (item.0.wp.network_type is undefined or item.0.wp.network_type == 'subdirectory')
+  with_nested:
+    - "{{ domains }}"
+    - "{{ nginx_defaults.subdirectory_multi_wp_site }}"
+
+- name: Copy configurations to new domain based configuration. (for a sub-domain multisite install)
+  copy:
+    remote_src: yes
+    src: "{{ item.1.src }}"
+    dest: "{{ nginx_defaults.file_path }}/{{ item.0.name }}.{{ item.1.type }}.conf"
+    force: no
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
+    and item.0.name not in domains_to_skip
+    and item.0.wp.install is defined
+    and item.0.wp.install == 'multisite'
+    and item.0.wp.network_type is defined
+    and item.0.wp.network_type == 'subdomain'
+  with_nested:
+    - "{{ domains }}"
+    - "{{ nginx_defaults.subdomain_multi_wp_site }}"
 
 - name: Modify root path directive configuration for configurations
   replace:
@@ -22,9 +56,41 @@
   when: >
     (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
     and item.0.name not in domains_to_skip
+    and (item.0.wp.install is undefined or item.0.wp.install == 'singlesite')
   with_nested:
     - "{{ domains }}"
     - "{{ nginx_defaults.single_wp_site }}"
+
+- name: Modify root path directive configuration for configurations (for a sub-directory multisite install)
+  replace:
+    dest: "{{ nginx_defaults.file_path }}/{{ item.0.name }}.{{ item.1.type }}.conf"
+    regexp: "{{ item.1.root_path_regex }}"
+    replace: '\1/home/{{ remote_web_user }}/www/{{ item.0.name }}\2'
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
+    and item.0.name not in domains_to_skip
+    and item.0.wp.install is defined
+    and item.0.wp.install == 'multisite'
+    and (item.0.wp.network_type is undefined or item.0.wp.network_type == 'subdirectory')
+  with_nested:
+    - "{{ domains }}"
+    - "{{ nginx_defaults.subdirectory_multi_wp_site }}"
+
+- name: Modify root path directive configuration for configurations (for a sub-domain multisite install)
+  replace:
+    dest: "{{ nginx_defaults.file_path }}/{{ item.0.name }}.{{ item.1.type }}.conf"
+    regexp: "{{ item.1.root_path_regex }}"
+    replace: '\1/home/{{ remote_web_user }}/www/{{ item.0.name }}\2'
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
+    and item.0.name not in domains_to_skip
+    and item.0.wp.install is defined
+    and item.0.wp.install == 'multisite'
+    and item.0.wp.network_type is defined
+    and item.0.wp.network_type == 'subdomain'
+  with_nested:
+    - "{{ domains }}"
+    - "{{ nginx_defaults.subdomain_multi_wp_site }}"
 
 - name: Replace template domain in configurations file with the actual domain
   replace:
@@ -34,9 +100,41 @@
   when: >
     (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
     and item.0.name not in domains_to_skip
+    and (item.0.wp.install is undefined or item.0.wp.install == 'singlesite')
   with_nested:
     - "{{ domains }}"
     - "{{ nginx_defaults.single_wp_site }}"
+
+- name: Replace template domain in configurations file with the actual domain (for a sub-directory multisite install)
+  replace:
+    path: "{{ nginx_defaults.file_path }}/{{ item.0.name }}.{{ item.1.type }}.conf"
+    regexp: "{{ item.1.domain_regex }}"
+    replace: '\1{{ item.0.name }}\2'
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
+    and item.0.name not in domains_to_skip
+    and item.0.wp.install is defined
+    and item.0.wp.install == 'multisite'
+    and (item.0.wp.network_type is undefined or item.0.wp.network_type == 'subdirectory')
+  with_nested:
+    - "{{ domains }}"
+    - "{{ nginx_defaults.subdirectory_multi_wp_site }}"
+
+- name: Replace template domain in configurations file with the actual domain (for a sub-domain multisite install)
+  replace:
+    path: "{{ nginx_defaults.file_path }}/{{ item.0.name }}.{{ item.1.type }}.conf"
+    regexp: "{{ item.1.domain_regex }}"
+    replace: '\1{{ item.0.name }}\2'
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
+    and item.0.name not in domains_to_skip
+    and item.0.wp.install is defined
+    and item.0.wp.install == 'multisite'
+    and item.0.wp.network_type is defined
+    and item.0.wp.network_type == 'subdomain'
+  with_nested:
+    - "{{ domains }}"
+    - "{{ nginx_defaults.subdomain_multi_wp_site }}"
 
 ## Modify lets encrypt to point to its own folder
 - name: Modify lets encrypt to point to its own folder for authorization (nonssl)
@@ -47,9 +145,43 @@
   when: >
     (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
     and item.0.name not in domains_to_skip
+    and (item.0.wp.install is undefined or item.0.wp.install == 'singlesite')
   with_nested:
     - "{{ domains }}"
     - "{{ nginx_defaults.single_wp_site }}"
+
+## Modify lets encrypt to point to its own folder
+- name: Modify lets encrypt to point to its own folder for authorization (nonssl) (for a sub-directory multisite install)
+  replace:
+    path: "{{ nginx_defaults.file_path }}/{{ item.0.name }}.{{ item.1.type }}.conf"
+    regexp: "{{ nginx_defaults.letsencrypt_regex }}"
+    replace: '\1/home/{{ remote_web_user }}/www/letsencrypt\2'
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
+    and item.0.name not in domains_to_skip
+    and item.0.wp.install is defined
+    and item.0.wp.install == 'multisite'
+    and (item.0.wp.network_type is undefined or item.0.wp.network_type == 'subdirectory')
+  with_nested:
+    - "{{ domains }}"
+    - "{{ nginx_defaults.subdirectory_multi_wp_site }}"
+
+## Modify lets encrypt to point to its own folder
+- name: Modify lets encrypt to point to its own folder for authorization (nonssl) (for a sub-domain multisite install)
+  replace:
+    path: "{{ nginx_defaults.file_path }}/{{ item.0.name }}.{{ item.1.type }}.conf"
+    regexp: "{{ nginx_defaults.letsencrypt_regex }}"
+    replace: '\1/home/{{ remote_web_user }}/www/letsencrypt\2'
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
+    and item.0.name not in domains_to_skip
+    and item.0.wp.install is defined
+    and item.0.wp.install == 'multisite'
+    and item.0.wp.network_type is defined
+    and item.0.wp.network_type == 'subdomain'
+  with_nested:
+    - "{{ domains }}"
+    - "{{ nginx_defaults.subdomain_multi_wp_site }}"
 
 ## Modify access_log_path directive
 - name: Modify access_log path directive for configurations.
@@ -61,9 +193,45 @@
   when: >
     (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
     and item.0.name not in domains_to_skip
+    and (item.0.wp.install is undefined or item.0.wp.install == 'singlesite')
   with_nested:
     - "{{ domains }}"
     - "{{ nginx_defaults.single_wp_site }}"
+
+## Modify access_log_path directive
+- name: Modify access_log path directive for configurations. (for a sub-directory multisite install)
+  lineinfile:
+    dest: "{{ nginx_defaults.file_path}}/{{ item.0.name }}.{{ item.1.type }}.conf"
+    regexp: "access_log"
+    line: "access_log /home/{{ remote_web_user }}/www/{{ item.0.name }}/logs/access.log;"
+    state: present
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
+    and item.0.name not in domains_to_skip
+    and item.0.wp.install is defined
+    and item.0.wp.install == 'multisite'
+    and (item.0.wp.network_type is undefined or item.0.wp.network_type == 'subdirectory')
+  with_nested:
+    - "{{ domains }}"
+    - "{{ nginx_defaults.subdirectory_multi_wp_site }}"
+
+## Modify access_log_path directive
+- name: Modify access_log path directive for configurations. (for a sub-domain multisite install)
+  lineinfile:
+    dest: "{{ nginx_defaults.file_path}}/{{ item.0.name }}.{{ item.1.type }}.conf"
+    regexp: "access_log"
+    line: "access_log /home/{{ remote_web_user }}/www/{{ item.0.name }}/logs/access.log;"
+    state: present
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
+    and item.0.name not in domains_to_skip
+    and item.0.wp.install is defined
+    and item.0.wp.install == 'multisite'
+    and item.0.wp.network_type is defined
+    and item.0.wp.network_type == 'subdomain'
+  with_nested:
+    - "{{ domains }}"
+    - "{{ nginx_defaults.subdomain_multi_wp_site }}"
 
 
 ## modify error_log path directives
@@ -76,9 +244,47 @@
   when: >
     (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
     and item.0.name not in domains_to_skip
+    and (item.0.wp.install is undefined or item.0.wp.install == 'singlesite')
   with_nested:
     - "{{ domains }}"
     - "{{ nginx_defaults.single_wp_site }}"
+
+
+## modify error_log path directives
+- name: Modify error_log path directive for all domain (for a sub-directory multisite install)
+  lineinfile:
+    dest: "{{ nginx_defaults.file_path}}/{{ item.0.name }}.{{ item.1.type }}.conf"
+    regexp: "error_log"
+    line: "error_log /home/{{ remote_web_user }}/www/{{ item.0.name }}/logs/error.log;"
+    state: present
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
+    and item.0.name not in domains_to_skip
+    and item.0.wp.install is defined
+    and item.0.wp.install == 'multisite'
+    and (item.0.wp.network_type is undefined or item.0.wp.network_type == 'subdirectory')
+  with_nested:
+    - "{{ domains }}"
+    - "{{ nginx_defaults.subdirectory_multi_wp_site }}"
+
+
+## modify error_log path directives
+- name: Modify error_log path directive for all domain (for a sub-domain multisite install)
+  lineinfile:
+    dest: "{{ nginx_defaults.file_path}}/{{ item.0.name }}.{{ item.1.type }}.conf"
+    regexp: "error_log"
+    line: "error_log /home/{{ remote_web_user }}/www/{{ item.0.name }}/logs/error.log;"
+    state: present
+  when: >
+    (("all" in domains_to_use and "none" in domains_to_skip) or item.0.name in domains_to_use)
+    and item.0.name not in domains_to_skip
+    and item.0.wp.install is defined
+    and item.0.wp.install == 'multisite'
+    and item.0.wp.network_type is defined
+    and item.0.wp.network_type == 'subdomain'
+  with_nested:
+    - "{{ domains }}"
+    - "{{ nginx_defaults.subdomain_multi_wp_site }}"
 
 ## does the ssl conf symlink exist?
 - name: Does ssl configuration symlink exist?

--- a/roles/wordpress/tasks/main.yml
+++ b/roles/wordpress/tasks/main.yml
@@ -100,6 +100,7 @@
     args:
       chdir: '/home/{{ remote_web_user }}/www/{{ item.name }}'
     register: wp_installed
+    ignore_errors: true
     when: >
       (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
       and item.name not in domains_to_skip

--- a/roles/wordpress/tasks/main.yml
+++ b/roles/wordpress/tasks/main.yml
@@ -114,9 +114,25 @@
       (item.1.skipped is undefined or not item.1.skipped)
       and 'Error:' not in item.1.stderr
       and item.1.rc != 0
+      and (item.0.wp.install is undefined or item.0.wp.install == 'singlesite')
     with_together:
      - "{{ domains }}"
      - "{{ wp_installed.results }}"
+
+  - name: Install WordPress Multisite using wp-cli
+    command: wp core multisite-install --url={{ item.0.name|quote }} --title={{ item.0.wp.site_title|quote }} {{ (item.0.wp.network_type is defined and item.0.wp.network_type == 'subdomain') | ternary('--subdomains', '') }} --admin_user={{ item.0.wp.admin_user|quote }} --admin_password={{ item.0.wp.admin_pass|quote }} --admin_email={{ item.0.wp.admin_email|quote }}
+    args:
+      chdir: '/home/{{ remote_web_user }}/www/{{ item.0.name }}'
+    when: >
+      (item.1.skipped is undefined or not item.1.skipped)
+      and 'Error:' not in item.1.stderr
+      and item.1.rc != 0
+      and item.0.wp.install is defined
+      and item.0.wp.install == 'multisite'
+    with_together:
+     - "{{ domains }}"
+     - "{{ wp_installed.results }}"
+
 
   become: true
   become_user: "{{ remote_web_user }}"

--- a/vars-sample.yml
+++ b/vars-sample.yml
@@ -51,6 +51,10 @@ domains:
     scheme: https://
     # if configured then a wp site is setup. Otherwise a plain php based configuration is used
     wp:
+      # Set the WordPress installation type - multisite or singlesite. If not provided defaults to 'singlesite'.
+      install: multisite
+      # WordPress Multisite installation network type. If not provided defaults to 'subdirectory'.
+      network_type: subdomain
       admin_user: username
       # plain_text you can change after site creation
       admin_pass: admin_password


### PR DESCRIPTION
This relies on: https://github.com/nerrad/wordpress-nginx/pull/1

## Functionality this Pull Request adds
- ability to install WP as MultiSite (SSL and non-SSL) - new `domains.wp.install` variable;
- ability to select what network type should the multisite use: sub-domain or sub-directory  - new `domains.wp.network_type` variable;
- this also fixes the `TASK [wordpress : Is WordPress already installed]` that was failing on a `non-zero` return code and breaking the play;
- for some reason the `root_path_regex` in `nginxsites/defaults/main.yml` was not matching the appropriate string if end-of-line (`$`) mark is present in that regex resulting in inappropriate nginx configurations. With the changes in this pull request it works better.

### How has this been tested
- This was tested locally by setting up a new web server on a fresh machine with a mix of WP installs by using this Ansible Playbook (branch). WP single sites and variation of multisites with a mix of new variables were tested.