### PR TITLE
Restart nginx after letsencrypt cert renewal

### DIFF
--- a/roles/buildmachine.webhook.listener/tasks/main.yml
+++ b/roles/buildmachine.webhook.listener/tasks/main.yml
@@ -125,7 +125,7 @@
   cron:
     name: letsencrypt_renewal_{{ webhook.domain }}
     special_time: weekly
-    job: letsencrypt --renew certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ webhook.domain }} && service nginx reload
+    job: (letsencrypt --renew certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ webhook.domain }} && service nginx restart) 2>&1 | logger -t letsencrypt_renewal
   when: webhook is defined and webhook.domain is defined
 
 - name: Add message to post_run_messages with webhook.

--- a/roles/grunt-buildmachine/tasks/main.yml
+++ b/roles/grunt-buildmachine/tasks/main.yml
@@ -164,7 +164,7 @@
   cron:
     name: letsencrypt_renewal_{{ buildmachine.build_creds.archiveDomain }}
     special_time: weekly
-    job: letsencrypt --renew certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ buildmachine.build_creds.archiveDomain }} && service nginx reload
+    job: (letsencrypt --renew certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ buildmachine.build_creds.archiveDomain }} && service nginx restart) 2>&1 | logger -t letsencrypt_renewal
   when: >
     buildmachine is defined
     and buildmachine.build_creds is defined

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -47,7 +47,7 @@
   cron:
     name: letsencrypt_renewal_{{ item.name }}
     special_time: weekly
-    job: letsencrypt --renew certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ item.name }} && service nginx reload
+    job: (letsencrypt --renew certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ item.name }} && service nginx restart) 2>&1 | logger -t letsencrypt_renewal
   when: >
     (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
     and item.name not in domains_to_skip


### PR DESCRIPTION
## Problem this Pull Request solves
The cert renewal cron job script failed to renew several certificates on some servers that were setup by this playbook. Just restarting (instead of reloading) nginx on those servers seemed to fix the issue of new certificates not being used. Work in this PR makes changes to the cron job script so that nginx is restarted after a cert several, instead of just the service configs being reloaded. Work here also adds logging of the `letsencrypt_renewal_` cron job output (into a syslog).

## Testing
- This script was tested on a local install.