### PR TITLE
Allow changing/updating the PHP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WordPress Ansible Playbook 
 
-This repository contains an ansible playbook for provisioning a WordPress based server with both a production and staging website, optional ssl certificates (provided free via letsencrypt), PHP 7.1, Mariadb, wp-cli, and nginx.
+This repository contains an ansible playbook for provisioning a WordPress based server with both a production and staging website, optional ssl certificates (provided free via letsencrypt), PHP 7.3, Mariadb, wp-cli, and nginx.
 
 > Note: currently this is oriented towards a Ubuntu or Debian based box.
 
@@ -15,7 +15,7 @@ The following roles are in this playbook.
 | ssh |  Disables root login and password authentication for ssh (hardening) | init |
 | nginx | Clones nginx config from the provided repository and configures default settings (including ssl global settings, catchall logs, and the default catchall config) | web, nginx |
 |nginxsites | Configures the nginx conf files for the registered domains. While this role does setup both ssl and non-ssl configs for the provided domain(s), it only _activates_ the non-ssl config.  | nginx, web, sites      |
-| php | Installs PHP 7.1 and all necessary php extensions WordPress needs.  Also modifies the php configs to set the web user etc. | init |
+| php | Installs PHP 7.3 (by default) and all necessary php extensions WordPress needs.  Also modifies the php configs to set the web user etc. | init |
 | mariadb | Installs `mariadb-server` and `python-mysqldb`, sets up root password for all root accounts (generated server side), creates .my.cnf with root password creds (to `/root/.my.cnf` on the server), deletes anonymous mysql server user for server hostname and for local host and removes the mysql test database. | init |
 | wp-cli | Installs wp-cli | init
 | wordpress | Installs and sets up wp sites for given domains.  You will end up with working vanilla WordPress sites for those domains on the server | web, wordpress |
@@ -27,7 +27,7 @@ The following roles are in this playbook.
 | grunt | adds grunt-cli to the server. | grunt
 | geerlingguy.composer | adds composer to the server | composer
 | geerlingguy.redis | adds redis to the server |  redis
-| php-redis | adds the php7.1 module for redis to the server | redis
+| php-redis | adds the php7.3 module for redis to the server | redis
 | buildmachine.webhook.listener | Sets up the [webhook listener](https://github.com/nerrad/buildmachine-webhook-listener) for the Grunt Buildmachine for WordPress plugins | webhook, buildmachine
 | grunt-buildmachine | Sets up the [Grunt Buildmachine for WordPress Plugins](https://github.com/eventespresso/grunt-wp-plugin-buildmachine) service. | buildmachine, gruntbm
 
@@ -86,6 +86,11 @@ Of course if _do_ have the server publicly accessible for your given domains and
 
 ```
 ansible-playbook playbook.yml
+```
+
+You can also update or downgrade the PHP version by setting the `php_fpm.version` variable in your `vars.yml` and running just the `init` tag:
+```
+ansible-playbook playbook.yml --tags="init"
 ```
 
 So you can see with the tags, there's many options for how you use this playbook!

--- a/roles/php-redis/defaults/main.yml
+++ b/roles/php-redis/defaults/main.yml
@@ -1,0 +1,2 @@
+php_fpm:
+  version: 7.3

--- a/roles/php-redis/tasks/main.yml
+++ b/roles/php-redis/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 # install php redis for php7.1
-- name: "Install php-redis for php7.1"
+- name: "Install php-redis for php{{ php_fpm.version }}"
   apt:
-    name: 'php7.1-redis'
+    name: 'php{{ php_fpm.version }}-redis'
     state: present
     force: yes
     update_cache: yes

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -1,0 +1,2 @@
+php_fpm:
+  version: 7.3

--- a/roles/php/handlers/main.yml
+++ b/roles/php/handlers/main.yml
@@ -1,15 +1,15 @@
 ---
 - name: start php
   service:
-    name: php7.1-fpm
+    name: php{{ php_fpm.version }}-fpm
     state: started
 
 - name: reload php
   service:
-    name: php7.1-fpm
+    name: php{{ php_fpm.version }}-fpm
     state: reloaded
 
 - name: restart php
   service:
-    name: php7.1-fpm
+    name: php{{ php_fpm.version }}-fpm
     state: restarted

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -5,29 +5,34 @@
 
 - name: Install PHP
   apt:
-    name: "{{ item }}"
+    pkg:
+      - php{{ php_fpm.version }}
+      - php{{ php_fpm.version }}-cli
+      - php{{ php_fpm.version }}-common
+      - php{{ php_fpm.version }}-curl
+      - php{{ php_fpm.version }}-dev
+      - php{{ php_fpm.version }}-fpm
+      - php{{ php_fpm.version }}-gd
+      - php{{ php_fpm.version }}-mbstring
+      - php{{ php_fpm.version }}-mysql
+      - php{{ php_fpm.version }}-opcache
+      - php{{ php_fpm.version }}-xml
+      - php{{ php_fpm.version }}-xmlrpc
+      - php{{ php_fpm.version }}-zip
     state: present
-    force: yes
     update_cache: yes
-  with_items:
-    - php7.1
-    - php7.1-cli
-    - php7.1-common
-    - php7.1-curl
-    - php7.1-dev
-    - php7.1-fpm
-    - php7.1-gd
-    - php7.1-mbstring
-    - php7.1-mcrypt
-    - php7.1-mysql
-    - php7.1-opcache
-    - php7.1-xml
-    - php7.1-xmlrpc
-    - php7.1-zip
+
+- name: Install PHP mcrypt
+  apt:
+    pkg:
+      - php{{ php_fpm.version }}-mcrypt
+    state: present
+    update_cache: yes
+  when: php_fpm.version < 7.2
 
 - name: Set PHP user
   lineinfile:
-    dest: /etc/php/7.1/fpm/pool.d/www.conf
+    dest: /etc/php/{{ php_fpm.version }}/fpm/pool.d/www.conf
     regexp: "^user"
     line: "user = {{ remote_web_user }}"
     state: present
@@ -35,7 +40,7 @@
 
 - name: Set PHP group
   lineinfile:
-    dest: /etc/php/7.1/fpm/pool.d/www.conf
+    dest: /etc/php/{{ php_fpm.version }}/fpm/pool.d/www.conf
     regexp: "^group"
     line: "group = {{ remote_web_user }}"
     state: present
@@ -43,7 +48,7 @@
 
 - name: Set PHP listen owner
   lineinfile:
-    dest: /etc/php/7.1/fpm/pool.d/www.conf
+    dest: /etc/php/{{ php_fpm.version }}/fpm/pool.d/www.conf
     regexp: "^listen\\.owner"
     line: "listen.owner = {{ remote_web_user }}"
     state: present
@@ -51,7 +56,7 @@
 
 - name: Set PHP listen group
   lineinfile:
-    dest: /etc/php/7.1/fpm/pool.d/www.conf
+    dest: /etc/php/{{ php_fpm.version }}/fpm/pool.d/www.conf
     regexp: "^listen\\.group"
     line: "listen.group = {{ remote_web_user }}"
     state: present
@@ -59,7 +64,7 @@
 
 - name: Set PHP upload max filesize
   lineinfile:
-    dest: /etc/php/7.1/fpm/php.ini
+    dest: /etc/php/{{ php_fpm.version }}/fpm/php.ini
     regexp: "^upload_max_filesize"
     line: "upload_max_filesize = 128M"
     state: present
@@ -67,8 +72,24 @@
 
 - name: Set PHP post max filesize
   lineinfile:
-    dest: /etc/php/7.1/fpm/php.ini
+    dest: /etc/php/{{ php_fpm.version }}/fpm/php.ini
     regexp: "^post_max_size"
     line: "post_max_size = 128M"
     state: present
   notify: reload php
+
+- name: Create a PHP upstrem for NGINX
+  copy:
+    dest: /etc/nginx/upstreams/php{{ php_fpm.version }}.conf
+    content: |
+      upstream php{{ php_fpm.version }} {
+          server unix:/run/php/php{{ php_fpm.version }}-fpm.sock;
+      }
+  notify: restart nginx
+
+- name: Set the PHP upstrem for NGINX
+  replace:
+    path: /etc/nginx/global/php-pool.conf
+    regexp: 'default php([0-9]+\.?)+'
+    replace: "default php{{ php_fpm.version }}"
+  notify: restart nginx

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -78,7 +78,7 @@
     state: present
   notify: reload php
 
-- name: Create a PHP upstrem for NGINX
+- name: Create a PHP upstream for NGINX
   copy:
     dest: /etc/nginx/upstreams/php{{ php_fpm.version }}.conf
     content: |
@@ -87,7 +87,7 @@
       }
   notify: restart nginx
 
-- name: Set the PHP upstrem for NGINX
+- name: Set the PHP upstream for NGINX
   replace:
     path: /etc/nginx/global/php-pool.conf
     regexp: 'default php([0-9]+\.?)+'

--- a/vars-sample.yml
+++ b/vars-sample.yml
@@ -14,6 +14,11 @@ remote_web_user_password: "EncryptedSecretString"
 # created.  The default is usually sufficient if you've already got keys generated in the default location.
 web_user_ssh_public_key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
 
+## -- PHP configuration -- ##
+php_fpm:
+  # PHP version to install. Defaults to PHP 7.3.
+  version: 7.2
+
 ## -- nginx configuration -- ##
 nginx:
   # repository used for the main nginx configuration folder. Currently the nginx role is DEPENDENT on this repository.


### PR DESCRIPTION
This adds a possibility to set the PHP version you want to install.

This also changes the default PHP version to 7.3.

Now, you can also update or downgrade the PHP version by setting the `php_fpm.version` variable in your `vars.yml` and running just the `init` tag:
```
ansible-playbook playbook.yml --tags="init"
```

Tested with PHP 5.6, 7.0, 7.1, 7.2, 7.3.